### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/jsonrpc_io_client.dart
+++ b/lib/jsonrpc_io_client.dart
@@ -47,7 +47,7 @@ class ServerProxy extends ServerProxyBase {
     String jsonContent = '';
     Completer c = Completer();
 
-    response.transform(utf8.decoder).listen((dynamic contents) {
+    utf8.decoder.bind(response).listen((dynamic contents) {
       jsonContent += contents.toString();
     }, onDone: () {
       if (response.statusCode == 204 || jsonContent.isEmpty) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: jsonrpc2
-version: 2.0.0
+version: 2.0.1
 author: Jim Washington <washington.jim@gmail.com>
 description: JSON-RPC (v2.0) utilities for web applications. It's like XML-RPC, for calling methods on a remote server, but using JSON.
 homepage: https://github.com/jwashin/jsonrpc2-dart


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900